### PR TITLE
New `super` keyword example.

### DIFF
--- a/ruby_oop_design.md
+++ b/ruby_oop_design.md
@@ -76,14 +76,14 @@ If you have overriden a parent class function but now still need access to the p
 ```
 class Dog
 	def speak
-		return "Woof"
+		puts "I'm a dog."
 	end
 end
 
 class Pitbull < Dog
 	def speak
-		puts 'Instead of woof...'
 		super                    #If there were any arguments, it would be super(...)
+		puts 'But I'm also a pitbull...'
 	end
 end
 ```


### PR DESCRIPTION
I found this example to be better suited for the `super` example.
